### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RecyclerView and CardView
 Demo for using RecylcerView and CardView with Android L new features.
 
-##Prerequisites
+## Prerequisites
  - android-support-v7
  - Recyclerview
  - Cardview
@@ -22,7 +22,7 @@ dependencies {
 ```
 
 ## Usage
-####RecyclerView
+#### RecyclerView
 ```
    <android.support.v7.widget.RecyclerView
         android:id="@+id/list"
@@ -34,7 +34,7 @@ dependencies {
 ```
 
 
-####CardView
+#### CardView
 ```
 <android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="horizontal" android:layout_width="match_parent"
@@ -75,7 +75,7 @@ dependencies {
 ```
 
 
-#License
+# License
 	Copyright (C) 2014 CommonQ 
 
 	Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
